### PR TITLE
feat: Add redirect_urls resource

### DIFF
--- a/example/main.tf
+++ b/example/main.tf
@@ -10,14 +10,38 @@ provider "msgraph" {
   use_cli = true
 }
 
-data "msgraph_groups" "groups" {
-  group_id = "d2ec52ab-f8ec-463a-ba99-7561719b984b"
+resource "msgraph_app_redirect_uris" "uris" {
+  app_object_id = "c52d8e63-4117-4b84-8856-879967d31606"
+  #  redirect_uris {
+  #    url  = "https://contoso.com"
+  #    type = "Web"
+  #  }
+  redirect_uris {
+    url  = "https://contoso2.com"
+    type = "Web"
+  }
+  redirect_uris {
+    url  = "https://contoso3.com"
+    type = "Web"
+  }
+
+  tolerance_override = true
 }
 
-output "group_ids" {
-  value = data.msgraph_groups.groups.group_ids
-}
+resource "msgraph_app_redirect_uris" "uris2" {
+  app_object_id = "c52d8e63-4117-4b84-8856-879967d31606"
+  #  redirect_uris {
+  #    url  = "https://contoso.com"
+  #    type = "Web"
+  #  }
+  redirect_uris {
+    url  = "https://contoso2.com"
+    type = "Web"
+  }
+  redirect_uris {
+    url  = "https://contoso4.com"
+    type = "Web"
+  }
 
-output "user_ids" {
-  value = data.msgraph_groups.groups.user_ids
+  tolerance_override = true
 }

--- a/go.mod
+++ b/go.mod
@@ -58,11 +58,13 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/oklog/run v1.0.0 // indirect
+	github.com/samber/lo v1.37.0 // indirect
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	github.com/vmihailenco/msgpack/v4 v4.3.12 // indirect
 	github.com/vmihailenco/tagparser v0.1.1 // indirect
 	github.com/zclconf/go-cty v1.12.1 // indirect
 	golang.org/x/crypto v0.0.0-20220517005047-85d78b3ac167 // indirect
+	golang.org/x/exp v0.0.0-20220303212507-bbda1eaf7a17 // indirect
 	golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2 // indirect
 	golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6 // indirect
 	golang.org/x/text v0.3.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -274,6 +274,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/samber/lo v1.37.0 h1:XjVcB8g6tgUp8rsPsJ2CvhClfImrpL04YpQHXeHPhRw=
+github.com/samber/lo v1.37.0/go.mod h1:9vaz2O4o8oOnK23pd2TrXufcbdbJIa3b6cstBWKpopA=
 github.com/sebdah/goldie v1.0.0/go.mod h1:jXP4hmWywNEwZzhMuv2ccnqTSFpuq8iyQhtQdkkZBH4=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
@@ -333,6 +335,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20220303212507-bbda1eaf7a17 h1:3MTrJm4PyNL9NBqvYDSj3DHl46qQakyfqfWo4jgfaEM=
+golang.org/x/exp v0.0.0-20220303212507-bbda1eaf7a17/go.mod h1:lgLbSvA5ygNOMpwM/9anMpWVlVJ7Z+cHWq/eFuinpGE=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/internal/clients/client.go
+++ b/internal/clients/client.go
@@ -35,6 +35,7 @@ type Client struct {
 		MsGraphClient *msgraph.ServicePrincipalsClient
 	}
 	GroupsClient *msgraph.GroupsClient
+	AppClient    *msgraph.ApplicationsClient
 }
 
 func (client *Client) build(ctx context.Context, o *common.ClientOptions) error { //nolint:unparam
@@ -45,10 +46,12 @@ func (client *Client) build(ctx context.Context, o *common.ClientOptions) error 
 	client.ServicePrincipalClient.AadClient = &spAadClient
 	client.ServicePrincipalClient.MsGraphClient = msgraph.NewServicePrincipalsClient(o.TenantID)
 	client.GroupsClient = msgraph.NewGroupsClient(o.TenantID)
+	client.AppClient = msgraph.NewApplicationsClient(o.TenantID)
 
 	o.ConfigureAadClient(&client.ServicePrincipalClient.AadClient.Client)
 	o.ConfigureMsGraphClient(&client.ServicePrincipalClient.MsGraphClient.BaseClient)
 	o.ConfigureMsGraphClient(&client.GroupsClient.BaseClient)
+	o.ConfigureMsGraphClient(&client.AppClient.BaseClient)
 
 	if client.EnableMsGraphBeta {
 		// Acquire an access token upfront so we can decode and populate the JWT claims

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -53,7 +53,7 @@ func TestAccProvider_cliAuth(t *testing.T) {
 			EnableAzureCliToken: true,
 		}
 
-		return buildClient(ctx, provider, authConfig, aadBuilder, "", true)
+		return buildClient(ctx, provider, authConfig, aadBuilder, "")
 	}
 
 	d := provider.Configure(ctx, terraform.NewResourceConfigRaw(nil))
@@ -101,7 +101,7 @@ func TestAccProvider_clientCertificateAuth(t *testing.T) {
 			ClientCertPassword:   d.Get("client_certificate_password").(string),
 		}
 
-		return buildClient(ctx, provider, authConfig, aadBuilder, "", true)
+		return buildClient(ctx, provider, authConfig, aadBuilder, "")
 	}
 
 	d := provider.Configure(ctx, terraform.NewResourceConfigRaw(nil))
@@ -147,7 +147,7 @@ func TestAccProvider_clientSecretAuth(t *testing.T) {
 			ClientSecret:           d.Get("client_secret").(string),
 		}
 
-		return buildClient(ctx, provider, authConfig, aadBuilder, "", true)
+		return buildClient(ctx, provider, authConfig, aadBuilder, "")
 	}
 
 	d := provider.Configure(ctx, terraform.NewResourceConfigRaw(nil))

--- a/internal/provider/services.go
+++ b/internal/provider/services.go
@@ -1,13 +1,13 @@
 package provider
 
 import (
-	"github.com/pubg/terraform-provider-msgraph/internal/services/approleassignment"
+	"github.com/pubg/terraform-provider-msgraph/internal/services/apps"
 	"github.com/pubg/terraform-provider-msgraph/internal/services/groups"
 )
 
 func SupportedServices() []ServiceRegistration {
 	return []ServiceRegistration{
-		approleassignment.Registration{},
+		apps.Registration{},
 		groups.Registration{},
 	}
 }

--- a/internal/services/apps/app_redirect_uris.go
+++ b/internal/services/apps/app_redirect_uris.go
@@ -1,0 +1,264 @@
+package apps
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/manicminer/hamilton/odata"
+	"github.com/pubg/terraform-provider-msgraph/internal/clients"
+	"github.com/pubg/terraform-provider-msgraph/internal/tf"
+)
+
+func appRedirectUris() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: appRedirectUrisResourceUpdate,
+		UpdateContext: appRedirectUrisResourceUpdate,
+		ReadContext:   appRedirectUrisResourceRead,
+		DeleteContext: appRedirectUrisResourceDelete,
+
+		Schema: map[string]*schema.Schema{
+			"app_object_id": {
+				Description:      "object_id of target Application",
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				ValidateDiagFunc: validation.ToDiagFunc(validation.IsUUID),
+			},
+
+			"redirect_uris": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"url": {
+							Description:      "A reply URL, You can find restrictions and limitations are this document. https://learn.microsoft.com/en-us/azure/active-directory/develop/reply-url",
+							Type:             schema.TypeString,
+							Required:         true,
+							ValidateDiagFunc: validation.ToDiagFunc(validation.IsURLWithHTTPorHTTPS),
+						},
+						"type": {
+							Description:      "Type of Redirect Url, One of [Web, InstalledClient, Spa]",
+							Type:             schema.TypeString,
+							Required:         true,
+							ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{"Web", "InstalledClient", "Spa"}, false)),
+						},
+					},
+				},
+			},
+
+			"tolerance_override": {
+				Description: "If some urls are already exist in target application, It may occur resource ownership conflict. If you want ignore this error, enable `tolerance_override` to true",
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+			},
+		},
+	}
+}
+
+func appRedirectUrisResourceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*clients.Client).AppClient
+
+	appId := d.Get("app_object_id").(string)
+
+	app, _, err := client.Get(ctx, appId, odata.Query{})
+	if err != nil {
+		return tf.ErrorDiagF(err, "Application not found, app_id(%s)", appId)
+	}
+
+	if !d.HasChange("redirect_uris") {
+		return appRedirectUrisResourceRead(ctx, d, meta)
+	}
+
+	toleranceOverride := d.Get("tolerance_override").(bool)
+
+	oldRaw, newRaw := d.GetChange("redirect_uris")
+	oldWeb, oldPub, oldSpa := classifyUrls(oldRaw)
+	newWeb, newPub, newSpa := classifyUrls(newRaw)
+
+	var webUrls = deRefSlice(app.Web.RedirectUris)
+	webUrls, isOverrode := applyUrls(webUrls, oldWeb, newWeb)
+	if !toleranceOverride && isOverrode {
+		return diag.Errorf("Conflict detected: Some urls are already exist in target application, It may occur resource ownership conflict. If you want ignore this error, enable `tolerance_override` to true")
+	}
+	app.Web.RedirectUris = toRefSlice(webUrls)
+
+	var pubUrls = deRefSlice(app.PublicClient.RedirectUris)
+	pubUrls, isOverrode = applyUrls(pubUrls, oldPub, newPub)
+	if !toleranceOverride && isOverrode {
+		return diag.Errorf("Conflict detected: Some urls are already exist in target application, It may occur resource ownership conflict. If you want ignore this error, enable `tolerance_override` to true")
+	}
+	app.PublicClient.RedirectUris = toRefSlice(pubUrls)
+
+	var spaUrls = deRefSlice(app.Spa.RedirectUris)
+	spaUrls, isOverrode = applyUrls(spaUrls, oldSpa, newSpa)
+	if !toleranceOverride && isOverrode {
+		return diag.Errorf("Conflict detected: Some urls are already exist in target application, It may occur resource ownership conflict. If you want ignore this error, enable `tolerance_override` to true")
+	}
+	app.Spa.RedirectUris = toRefSlice(spaUrls)
+
+	if _, err = client.Update(ctx, *app); err != nil {
+		return tf.ErrorDiagF(err, "Application update failed, app_id(%s)", appId)
+	}
+
+	// Check Application updated to desired state
+	updatedApp, _, err := client.Get(ctx, appId, odata.Query{})
+	if err != nil {
+		return tf.ErrorDiagF(err, "Application not found, app_id(%s)", appId)
+	}
+	if !equalsSlice(deRefSlice(app.Web.RedirectUris), deRefSlice(updatedApp.Web.RedirectUris)) {
+		return diag.Errorf("Updated Application Web urls are not desired value, desired: %v, actual: %v", *app.Web.RedirectUris, *updatedApp.Web.RedirectUris)
+	}
+	if !equalsSlice(deRefSlice(app.PublicClient.RedirectUris), deRefSlice(updatedApp.PublicClient.RedirectUris)) {
+		return diag.Errorf("Updated Application InstalledClient urls are not desired value, desired: %v, actual: %v", *app.PublicClient.RedirectUris, *updatedApp.PublicClient.RedirectUris)
+	}
+	if !equalsSlice(deRefSlice(app.Spa.RedirectUris), deRefSlice(updatedApp.Spa.RedirectUris)) {
+		return diag.Errorf("Updated Application Spa urls are not desired value, desired: %v, actual: %v", *app.Spa.RedirectUris, *updatedApp.Spa.RedirectUris)
+	}
+
+	return appRedirectUrisResourceRead(ctx, d, meta)
+}
+
+func appRedirectUrisResourceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*clients.Client).AppClient
+
+	appId := d.Get("app_object_id").(string)
+
+	_, _, err := client.Get(ctx, appId, odata.Query{})
+	if err != nil {
+		return tf.ErrorDiagF(err, "Cannot find target Application app_id(%s)", appId)
+	}
+
+	d.SetId(appId)
+	return nil
+}
+
+func appRedirectUrisResourceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*clients.Client).AppClient
+
+	appId := d.Get("app_object_id").(string)
+
+	app, _, err := client.Get(ctx, appId, odata.Query{})
+	if err != nil {
+		return tf.ErrorDiagF(err, "Cannot find target Application app_id(%s)", appId)
+	}
+
+	rawUris := d.Get("redirect_uris")
+	oldWeb, oldPub, oldSpa := classifyUrls(rawUris)
+
+	var webUrls = deRefSlice(app.Web.RedirectUris)
+	webUrls, _ = applyUrls(webUrls, oldWeb, nil)
+	app.Web.RedirectUris = toRefSlice(webUrls)
+
+	var pubUrls = deRefSlice(app.PublicClient.RedirectUris)
+	pubUrls, _ = applyUrls(pubUrls, oldPub, nil)
+	app.PublicClient.RedirectUris = toRefSlice(pubUrls)
+
+	var spaUrls = deRefSlice(app.Spa.RedirectUris)
+	spaUrls, _ = applyUrls(spaUrls, oldSpa, nil)
+	app.Spa.RedirectUris = toRefSlice(spaUrls)
+
+	if _, err = client.Update(ctx, *app); err != nil {
+		return tf.ErrorDiagF(err, "Application update failed, app_id(%s)", appId)
+	}
+
+	// Check Application updated to desired state
+	updatedApp, _, err := client.Get(ctx, appId, odata.Query{})
+	if err != nil {
+		return tf.ErrorDiagF(err, "Application not found, app_id(%s)", appId)
+	}
+	if !equalsSlice(deRefSlice(app.Web.RedirectUris), deRefSlice(updatedApp.Web.RedirectUris)) {
+		return diag.Errorf("Updated Application Web urls are not desired value, desired: %v, actual: %v", *app.Web.RedirectUris, *updatedApp.Web.RedirectUris)
+	}
+	if !equalsSlice(deRefSlice(app.PublicClient.RedirectUris), deRefSlice(updatedApp.PublicClient.RedirectUris)) {
+		return diag.Errorf("Updated Application InstalledClient urls are not desired value, desired: %v, actual: %v", *app.PublicClient.RedirectUris, *updatedApp.PublicClient.RedirectUris)
+	}
+	if !equalsSlice(deRefSlice(app.Spa.RedirectUris), deRefSlice(updatedApp.Spa.RedirectUris)) {
+		return diag.Errorf("Updated Application Spa urls are not desired value, desired: %v, actual: %v", *app.Spa.RedirectUris, *updatedApp.Spa.RedirectUris)
+	}
+
+	return nil
+}
+
+func classifyUrls(rawValue any) (web []string, pub []string, spa []string) {
+	if rawValue == nil {
+		return
+	}
+
+	for _, rawUrl := range rawValue.([]any) {
+		urlSpec := rawUrl.(map[string]any)
+		url := urlSpec["url"].(string)
+		switch urlSpec["type"] {
+		case "Web":
+			web = append(web, url)
+		case "InstalledClient":
+			pub = append(pub, url)
+		case "Spa":
+			spa = append(spa, url)
+		}
+	}
+
+	return
+}
+
+func applyUrls(currentUrls []string, oldUrls []string, newUrls []string) (urls []string, overrode bool) {
+	urlMap := map[string]any{}
+	for _, url := range currentUrls {
+		urlMap[url] = nil
+	}
+	for _, url := range oldUrls {
+		delete(urlMap, url)
+	}
+	for _, url := range newUrls {
+		if _, found := urlMap[url]; found {
+			// Find overrode
+			overrode = true
+		}
+		urlMap[url] = nil
+	}
+
+	for url, _ := range urlMap {
+		urls = append(urls, url)
+	}
+	return
+}
+
+func equalsSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	aMap := map[string]any{}
+	for _, v := range a {
+		aMap[v] = nil
+	}
+	for _, v := range b {
+		if _, found := aMap[v]; found {
+			delete(aMap, v)
+		} else {
+			return false
+		}
+	}
+
+	if len(aMap) != 0 {
+		return false
+	}
+
+	return true
+}
+
+func deRefSlice(s *[]string) []string {
+	if s == nil {
+		return nil
+	}
+	return *s
+}
+
+func toRefSlice(s []string) *[]string {
+	if s == nil {
+		return nil
+	}
+	return &s
+}

--- a/internal/services/apps/app_role_assignment_resource.go
+++ b/internal/services/apps/app_role_assignment_resource.go
@@ -1,4 +1,4 @@
-package approleassignment
+package apps
 
 import (
 	"context"

--- a/internal/services/apps/app_role_assignment_resource_msgraph.go
+++ b/internal/services/apps/app_role_assignment_resource_msgraph.go
@@ -1,4 +1,4 @@
-package approleassignment
+package apps
 
 import (
 	"context"

--- a/internal/services/apps/registration.go
+++ b/internal/services/apps/registration.go
@@ -1,4 +1,4 @@
-package approleassignment
+package apps
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -8,13 +8,13 @@ type Registration struct{}
 
 // Name is the name of this Service
 func (r Registration) Name() string {
-	return "App Role Assignment"
+	return "Apps"
 }
 
 // WebsiteCategories returns a list of categories which can be used for the sidebar
 func (r Registration) WebsiteCategories() []string {
 	return []string{
-		"App Role Assignment",
+		"App",
 	}
 }
 
@@ -22,6 +22,7 @@ func (r Registration) WebsiteCategories() []string {
 func (r Registration) SupportedResources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{
 		"msgraph_app_role_assignment": appRoleAssignmentResource(),
+		"msgraph_app_redirect_uris":   appRedirectUris(),
 	}
 }
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -1,8 +1,6 @@
 ---
 layout: "msgraph"
 page_title: "Provider: MsGraph"
-description: |-
-  Use the Amazon Web Services (AWS) provider to interact with the many resources supported by AWS. You must configure the provider with the proper credentials before you can use it.
 ---
 
 # terraform-provider-msgraph
@@ -18,7 +16,9 @@ Microsoft don't recommend that you use them in your production apps. [MS Doc Her
 But, This API is the only way to managing AzureAD apps with GitOps style.
 
 ### Set up Custom Terraform Provider
-1. Add the providers. For example,
+
+Same as AzureAD Provider
+
 ```terraform
 terraform {
   ...
@@ -32,16 +32,41 @@ terraform {
 
     msgraph = {
       source = "pubg/msgraph"
-      version = "0.0.6"
     }
   }
 }
 
+# Access via ClientSecret 
+data "vault_generic_secret" "azure_credential_root" {
+  path = "secret/serviceprincipal/root"
+}
+        
 provider "azuread" {
-  use_microsoft_graph = true
+  alias = "tenant1"        
+        
+  tenant_id     = data.vault_generic_secret.azure_credential_root.data["tenant_id"]
+  client_id     = data.vault_generic_secret.azure_credential_root.data["client_id"]
+  client_secret = data.vault_generic_secret.azure_credential_root.data["client_secret"]
 }
 
 provider "msgraph" {
-  use_microsoft_graph = true
+  alias = "tenant1"
+          
+  tenant_id     = data.vault_generic_secret.azure_credential_root.data["tenant_id"]
+  client_id     = data.vault_generic_secret.azure_credential_root.data["client_id"]
+  client_secret = data.vault_generic_secret.azure_credential_root.data["client_secret"]
 }
+
+# Access via AzureCLI
+provider "azuread" {
+  alias = "tenant2"
+  use_cli = true
+}
+
+provider "msgraph" {
+  alias = "tenant2"
+  use_cli = true
+}
+
+...
 ```

--- a/website/docs/r/app_redirect_uris.html.markdown
+++ b/website/docs/r/app_redirect_uris.html.markdown
@@ -1,0 +1,57 @@
+---
+layout: "msgraph"
+subcategory: "Application"
+page_title: "MsGraph: msgraph_app_redirect_uris"
+description: |-
+  Add redirect uris to Application
+---
+
+# Resource: msgraph_app_redirect_uris
+
+Add redirect uris to Application
+
+## Example Usage
+
+```terraform
+resource "azuread_application" "shared_app" {
+   display_name = "Shared App"
+
+  web {
+    redirect_uris = [
+      "https://*.contoso.com/",
+    ]
+  }
+}
+
+resource "msgraph_app_redirect_uris" "per_cluster_app" {
+   app_object_id = azuread_application.shared_app.object_id
+  
+   redirect_uris {
+     url = "https://*.my-first-cluster.contoso.com/"
+     type = "Web"
+   }
+}
+```
+
+## Arguments Reference
+
+* `app_object_id` - (Required, uuid) The object_id of target Application 
+* `redirect_uris` - A `redirect_uris` block as documented blow, which configures redirect uri related settings for target application.
+* `tolerance_override` - (Optional, bool) If some urls are already exist in target application, It may occur resource ownership conflict. If you want ignore this error, enable `tolerance_override` to true (default false)
+
+---
+
+`redirect_uris` block supports the following:
+
+* `url` - (Required, string) A reply URL, You can find restrictions and limitations are this document. https://learn.microsoft.com/en-us/azure/active-directory/develop/reply-url
+* `type` - (Required, enum) Type of Redirect Url, One of [Web, InstalledClient, Spa]
+
+---
+
+## Attributes Reference
+
+* `id` - App redirect uris resource Id
+
+## Import
+
+Not support Terraform import

--- a/website/docs/r/app_role_assignment.html.markdown
+++ b/website/docs/r/app_role_assignment.html.markdown
@@ -3,7 +3,7 @@ layout: "msgraph"
 subcategory: "EnterpriseApplication"
 page_title: "MsGraph: msgraph_app_role_assignment"
 description: |-
-  Assign user or groups to EnterpriseApplication
+  Assign user or groups to EnterpriseApplication(ServicePrincipal)
 ---
 
 # Resource: msgraph_app_role_assignment


### PR DESCRIPTION
msgraph_app_redirect_urls 리소스를 추가합니다.
이 리소스는 단일 AD App에 redirect url을 각자 추가할 수 있게 만들어 줍니다.

# 기능

## redirect_uris
개별적으로 추가하길 원하는 uri를 리스트로 작성하면 됩니다.
Web, InstalledClient(PublicClient), Spa 타입을 지원합니다.

## tolerance_override
`msgraph_app_role_assignment` 와 마찬가지로 AD에서 redirect_url은 ownership을 제어할 수 없습니다.
동일한 url이 있으면 누가 소유권을 가져갈지 애매한 상황이 발생합니다.

기본적으로 `msgraph_app_redirect_urls` 리소스는 충돌 발생시 Resource Create 작업을 멈추도록 개발했습니다.

그러나 ownership을 공유하거나 덮어쓰기를 원하는 경우, tolerance_override을 true로 설정해 무시할 수 있습니다.